### PR TITLE
[Feat] [Scrum-223] 토큰 예치 및 취소 기록

### DIFF
--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/api/open/SmartContractTradeController.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/api/open/SmartContractTradeController.java
@@ -1,7 +1,7 @@
 package com.ddiring.Backend_BlockchainConnector.api.open;
 
 import com.ddiring.Backend_BlockchainConnector.common.dto.ApiResponseDto;
-import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.DepositWithPermitDto;
+import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.DepositDto;
 import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.TradeDto;
 import com.ddiring.Backend_BlockchainConnector.domain.dto.signature.PermitSignatureDto;
 import com.ddiring.Backend_BlockchainConnector.service.SmartContractTradeService;
@@ -29,14 +29,14 @@ public class SmartContractTradeController {
     }
 
     @PostMapping(value = "/deposit")
-    public ApiResponseDto<?> depositTokenWithPermit(@RequestBody @Valid DepositWithPermitDto depositDto) {
+    public ApiResponseDto<?> depositTokenWithPermit(@RequestBody @Valid DepositDto depositDto) {
         smartContractTradeService.deposit(depositDto);
 
         return ApiResponseDto.defaultOK();
     }
 
     @PostMapping(value = "/deposit/cancel")
-    public ApiResponseDto<?> cancelDeposit(@RequestBody @Valid DepositWithPermitDto cancelDepositDto) {
+    public ApiResponseDto<?> cancelDeposit(@RequestBody @Valid DepositDto cancelDepositDto) {
         smartContractTradeService.cancelDeposit(cancelDepositDto);
 
         return ApiResponseDto.defaultOK();

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/trade/DepositDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/trade/DepositDto.java
@@ -1,9 +1,5 @@
 package com.ddiring.Backend_BlockchainConnector.domain.dto.trade;
 
-import com.ddiring.Backend_BlockchainConnector.domain.entity.BlockchainLog;
-import com.ddiring.Backend_BlockchainConnector.domain.entity.SmartContract;
-import com.ddiring.Backend_BlockchainConnector.domain.enums.BlockchainRequestStatus;
-import com.ddiring.Backend_BlockchainConnector.domain.enums.BlockchainRequestType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -17,7 +13,7 @@ import java.math.BigInteger;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-public class DepositWithPermitDto {
+public class DepositDto {
     @NotBlank
     private String projectId;
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/entity/Deposit.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/entity/Deposit.java
@@ -1,0 +1,40 @@
+package com.ddiring.Backend_BlockchainConnector.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "deposit")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Deposit {
+    @Id
+    @Column(name = "deposit_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long depositId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "smart_contract_id", nullable = false)
+    private SmartContract smartContract;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "sell_id", nullable = false)
+    private Long sellId;
+
+    @Column(name = "token_amount", nullable = false)
+    private Long tokenAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "deposit_type", nullable = false)
+    private DepositType depositType;
+
+    public enum DepositType { DEPOSIT, CANCEL_DEPOSIT };
+
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
@@ -35,23 +35,25 @@ public class BlockchainLogMapper {
                 .build();
     }
 
-    public static BlockchainLog toEntityForDeposit(SmartContract contract) {
+    public static BlockchainLog toEntityForDeposit(SmartContract contract, Long orderId) {
         validateContract(contract);
         return BlockchainLog.builder()
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.DEPOSIT)
                 .requestStatus(BlockchainRequestStatus.PENDING)
+                .orderId(orderId)
                 .build();
     }
 
-    public static BlockchainLog toEntityForCancelDeposit(SmartContract contract) {
+    public static BlockchainLog toEntityForCancelDeposit(SmartContract contract, Long orderId) {
         validateContract(contract);
         return BlockchainLog.builder()
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.CANCEL_DEPOSIT)
                 .requestStatus(BlockchainRequestStatus.PENDING)
+                .orderId(orderId)
                 .build();
     }
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
@@ -35,45 +35,23 @@ public class BlockchainLogMapper {
                 .build();
     }
 
-    public static BlockchainLog toEntityForDepositSucceeded(SmartContract contract, String requestTransactionHash) {
+    public static BlockchainLog toEntityForDeposit(SmartContract contract) {
         validateContract(contract);
         return BlockchainLog.builder()
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.DEPOSIT)
                 .requestStatus(BlockchainRequestStatus.SUCCESS)
-                .requestTransactionHash(requestTransactionHash)
                 .build();
     }
 
-    public static BlockchainLog toEntityForDepositFailed(SmartContract contract) {
-        validateContract(contract);
-        return BlockchainLog.builder()
-                .projectId(contract.getProjectId())
-                .smartContract(contract)
-                .requestType(BlockchainRequestType.DEPOSIT)
-                .requestStatus(BlockchainRequestStatus.FAILURE)
-                .build();
-    }
-
-    public static BlockchainLog toEntityForCancelDepositSucceeded(SmartContract contract, String requestTransactionHash) {
+    public static BlockchainLog toEntityForCancelDeposit(SmartContract contract) {
         validateContract(contract);
         return BlockchainLog.builder()
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.CANCEL_DEPOSIT)
                 .requestStatus(BlockchainRequestStatus.SUCCESS)
-                .requestTransactionHash(requestTransactionHash)
-                .build();
-    }
-
-    public static BlockchainLog toEntityForCancelDepositFailed(SmartContract contract) {
-        validateContract(contract);
-        return BlockchainLog.builder()
-                .projectId(contract.getProjectId())
-                .smartContract(contract)
-                .requestType(BlockchainRequestType.CANCEL_DEPOSIT)
-                .requestStatus(BlockchainRequestStatus.FAILURE)
                 .build();
     }
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/BlockchainLogMapper.java
@@ -41,7 +41,7 @@ public class BlockchainLogMapper {
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.DEPOSIT)
-                .requestStatus(BlockchainRequestStatus.SUCCESS)
+                .requestStatus(BlockchainRequestStatus.PENDING)
                 .build();
     }
 
@@ -51,7 +51,7 @@ public class BlockchainLogMapper {
                 .projectId(contract.getProjectId())
                 .smartContract(contract)
                 .requestType(BlockchainRequestType.CANCEL_DEPOSIT)
-                .requestStatus(BlockchainRequestStatus.SUCCESS)
+                .requestStatus(BlockchainRequestStatus.PENDING)
                 .build();
     }
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/DepositMapper.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/mapper/DepositMapper.java
@@ -1,0 +1,37 @@
+package com.ddiring.Backend_BlockchainConnector.domain.mapper;
+
+import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.DepositDto;
+import com.ddiring.Backend_BlockchainConnector.domain.entity.Deposit;
+import com.ddiring.Backend_BlockchainConnector.domain.entity.SmartContract;
+
+public class DepositMapper {
+    private static void validateSmartContract(SmartContract contract) {
+        if (contract == null) {
+            throw new NullPointerException("Smart Contract is null");
+        }
+
+        if (contract.getIsActive() == false) {
+            throw new IllegalArgumentException("Smart Contract is not activated");
+        }
+    }
+
+    private static void validateDepositDto(DepositDto depositDto) {
+        if (depositDto == null) {
+            throw new NullPointerException("depositDto is null");
+        }
+    }
+
+    public static Deposit toEntity(SmartContract contract, DepositDto depositDto, Deposit.DepositType depositType) {
+        validateSmartContract(contract);
+
+        validateDepositDto(depositDto);
+
+        return Deposit.builder()
+                .smartContract(contract)
+                .sellId(depositDto.getSellId())
+                .userId(depositDto.getSellerAddress())
+                .tokenAmount(depositDto.getTokenAmount().longValue())
+                .depositType(depositType)
+                .build();
+    }
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/repository/DepositRepository.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/repository/DepositRepository.java
@@ -1,0 +1,9 @@
+package com.ddiring.Backend_BlockchainConnector.repository;
+
+import com.ddiring.Backend_BlockchainConnector.domain.entity.Deposit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepositRepository extends JpaRepository<Deposit,Long> {
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -2,7 +2,7 @@ package com.ddiring.Backend_BlockchainConnector.service;
 
 import com.ddiring.Backend_BlockchainConnector.common.exception.NotFound;
 import com.ddiring.Backend_BlockchainConnector.domain.mapper.BlockchainLogMapper;
-import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.DepositWithPermitDto;
+import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.DepositDto;
 import com.ddiring.Backend_BlockchainConnector.domain.dto.trade.TradeDto;
 import com.ddiring.Backend_BlockchainConnector.domain.dto.signature.PermitSignatureDto;
 import com.ddiring.Backend_BlockchainConnector.domain.dto.signature.domain.PermitSignatureDomain;

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -89,7 +89,7 @@ public class SmartContractTradeService {
             FractionalInvestmentToken smartContract = contractWrapper.getSmartContract(contractInfo.getSmartContractAddress());
 
             Deposit deposit = DepositMapper.toEntity(contractInfo, depositDto, Deposit.DepositType.DEPOSIT);
-            depositRepository.save(deposit);
+            Deposit updatedDeposit = depositRepository.save(deposit);
 
             BlockchainLog blockchainLog = BlockchainLogMapper.toEntityForDeposit(contractInfo);
             blockchainLogRepository.save(blockchainLog);
@@ -106,7 +106,7 @@ public class SmartContractTradeService {
                     .thenAccept(response -> {
                         log.info("[Smart Contract] 예금 성공: {}", response);
 
-                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(depositDto.getProjectId(), deposit.getDepositId(), BlockchainRequestType.DEPOSIT)
+                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(depositDto.getProjectId(), updatedDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
                                 .orElseThrow(() -> new NotFound("매칭되는 블록체인 기록을 찾을 수 없습니다."));
                         depositLog.updateSuccessResponse(response.getTransactionHash());
 
@@ -119,7 +119,7 @@ public class SmartContractTradeService {
                     .exceptionally(throwable -> {
                         log.error("[Smart Contract] 토큰 예치 요청 중 에러 발생 : {}", throwable.getMessage());
 
-                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(depositDto.getProjectId(), deposit.getDepositId(), BlockchainRequestType.DEPOSIT)
+                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(depositDto.getProjectId(), updatedDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
                                 .orElseThrow(() -> new NotFound("매칭되는 블록체인 기록을 찾을 수 없습니다."));
                         depositLog.updateFailureResponse();
 
@@ -146,7 +146,7 @@ public class SmartContractTradeService {
             FractionalInvestmentToken smartContract = contractWrapper.getSmartContract(contractInfo.getSmartContractAddress());
 
             Deposit cancelDeposit = DepositMapper.toEntity(contractInfo, cancelDepositDto, Deposit.DepositType.CANCEL_DEPOSIT);
-            depositRepository.save(cancelDeposit);
+            Deposit updatedCancelDeposit = depositRepository.save(cancelDeposit);
 
             BlockchainLog blockchainLog = BlockchainLogMapper.toEntityForCancelDeposit(contractInfo);
             blockchainLogRepository.save(blockchainLog);
@@ -163,7 +163,7 @@ public class SmartContractTradeService {
                     .thenAccept(response -> {
                         log.info("[Smart Contract] 예금 취소 성공: {}", response);
 
-                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), cancelDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
+                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), updatedCancelDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
                                 .orElseThrow(() -> new NotFound("매칭되는 블록체인 기록을 찾을 수 없습니다."));
                         depositLog.updateSuccessResponse(response.getTransactionHash());
 
@@ -175,7 +175,7 @@ public class SmartContractTradeService {
                     }).exceptionally(throwable -> {
                         log.error("[Smart Contract] 토큰 예치 취소 요청 중 에러 발생 : {}", throwable.getMessage());
 
-                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), cancelDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
+                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), updatedCancelDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
                                 .orElseThrow(() -> new NotFound("매칭되는 블록체인 기록을 찾을 수 없습니다."));
                         depositLog.updateFailureResponse();
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -148,7 +148,7 @@ public class SmartContractTradeService {
             Deposit cancelDeposit = DepositMapper.toEntity(contractInfo, cancelDepositDto, Deposit.DepositType.CANCEL_DEPOSIT);
             depositRepository.save(cancelDeposit);
 
-            BlockchainLog blockchainLog = BlockchainLogMapper.toEntityForDeposit(contractInfo);
+            BlockchainLog blockchainLog = BlockchainLogMapper.toEntityForCancelDeposit(contractInfo);
             blockchainLogRepository.save(blockchainLog);
 
             smartContract.cancelDeposit(

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -163,7 +163,7 @@ public class SmartContractTradeService {
                     .thenAccept(response -> {
                         log.info("[Smart Contract] 예금 취소 성공: {}", response);
 
-                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), updatedCancelDeposit.getDepositId(), BlockchainRequestType.DEPOSIT)
+                        BlockchainLog depositLog = blockchainLogRepository.findByProjectIdAndOrderIdAndRequestType(cancelDepositDto.getProjectId(), updatedCancelDeposit.getDepositId(), BlockchainRequestType.CANCEL_DEPOSIT)
                                 .orElseThrow(() -> new NotFound("매칭되는 블록체인 기록을 찾을 수 없습니다."));
                         depositLog.updateSuccessResponse(response.getTransactionHash());
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -201,8 +201,6 @@ public class SmartContractTradeService {
 
             FractionalInvestmentToken smartContract = contractWrapper.getSmartContract(contractInfo.getSmartContractAddress());
 
-            AtomicReference<BlockchainLog> blockchainLog = new AtomicReference<>();
-
             smartContract.requestTrade(
                             tradeDto.getTradeId().toString(),
                             tradeDto.getSellInfo().getSellId().toString(),
@@ -215,8 +213,8 @@ public class SmartContractTradeService {
                     .thenAccept(response -> {
                         log.info("[Smart Contract] 거래 요청 성공: {}", response);
 
-                        blockchainLog.set(BlockchainLogMapper.toEntityForTrade(contractInfo, response.getTransactionHash(), tradeDto.getTradeId()));
-                        blockchainLogRepository.save(blockchainLog.get());
+                        BlockchainLog blockchainLog = BlockchainLogMapper.toEntityForTrade(contractInfo, response.getTransactionHash(), tradeDto.getTradeId());
+                        blockchainLogRepository.save(blockchainLog);
 
                         kafkaMessageProducer.sendTradeRequestAcceptedEvent(tradeDto.getTradeId());
                     })

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractTradeService.java
@@ -76,7 +76,7 @@ public class SmartContractTradeService {
         }
     }
 
-    public void deposit(DepositWithPermitDto depositDto) {
+    public void deposit(DepositDto depositDto) {
         try {
             SmartContract contractInfo = smartContractRepository.findByProjectId(depositDto.getProjectId())
                     .orElseThrow(() -> new NotFound("스마트 컨트랙트를 찾을 수 없습니다"));
@@ -127,7 +127,7 @@ public class SmartContractTradeService {
         }
     }
 
-    public void cancelDeposit(DepositWithPermitDto cancelDepositDto) {
+    public void cancelDeposit(DepositDto cancelDepositDto) {
         try {
             SmartContract contractInfo = smartContractRepository.findByProjectId(cancelDepositDto.getProjectId())
                     .orElseThrow(() -> new NotFound("스마트 컨트랙트를 찾을 수 없습니다"));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #33 #36


## 📝작업 내용

> <img width="994" height="86" alt="image" src="https://github.com/user-attachments/assets/7f3fcadd-9585-479e-96e2-2d34ea4a90a8" />

> 1. 토큰 예치 및 취소 기능 추가:
>    + DepositDto 파일을 추가하고 엔티티와 매퍼, 리포지토리를 구성하여 토큰 예치 및 취소 요청을 처리하는 기반을 마련했습니다.
>    + Deposit 엔티티를 추가하고, 요청 정보(토큰 개수, 요청자 등)를 저장하도록 구성했습니다.
>    + 토큰 예치/취소 요청 시 PENDING 상태로 기록하고, 응답 시 상태를 업데이트하는 로직을 적용했습니다.
> 2. 블록체인 기록 로직 개선:
>    + BlockchainLog 엔티티에 orderId 필드를 추가하여 토큰 예치 및 취소 번호를 기록하도록 했습니다. 이를 통해 특정 요청에 대한 응답을 정확히 식별할 수 있습니다.
>    + 기존 #33 커밋에서 발생했던 BlockchainLog 업데이트 관련 버그를 수정하여, 요청-응답 간의 데이터 매핑이 올바르게 이루어지도록 했습니다.
>    + 엔티티 간의 관계 매핑을 수정하고 파일명을 변경하여 코드의 가독성과 유지보수성을 높였습니다.
> 3. 버그 수정 및 리팩토링:
>    + Deposit 엔티티의 외래키 제약 조건을 수정하여, BlockchainLog에 올바르게 기록되도록 했습니다.
>    + BlockchainLog에 예치 번호가 정확히 기록되도록 로직을 보완했습니다.
>    + Deposit 파일명과 예치 취소 관련 오타를 수정했습니다.


## 💬 리뷰 요구사항

> 없음
