### PR TITLE
[Fix] [Scrum-239] 크레딧 절약 로직 적용

### DIFF
--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/config/BlockchainProperties.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/config/BlockchainProperties.java
@@ -13,6 +13,7 @@ public class BlockchainProperties {
     private Etherscan etherscan;
     private Sepolia sepolia;
     private Admin admin;
+    private Web3j web3j;
 
     @Getter
     @Setter
@@ -45,5 +46,11 @@ public class BlockchainProperties {
         public static class Key {
             private String privateKey;
         }
+    }
+
+    @Getter
+    @Setter
+    public static class Web3j {
+        private Long pollingInterval;
     }
 }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/event/SmartContractConnectFailedEvent.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/event/SmartContractConnectFailedEvent.java
@@ -1,0 +1,45 @@
+package com.ddiring.Backend_BlockchainConnector.domain.event;
+
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SmartContractConnectFailedEvent {
+    public static final String TOPIC = "CONTRACT_CONNECT";
+
+    private String eventId;
+    private String eventType;          // CONTRACT_DEACTIVATED, CONTRACT_ADDED, CONTRACT_REMOVED 등
+    private Instant timestamp;
+    private SmartContractConnectFailedPayload payload;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class SmartContractConnectFailedPayload {
+        private String projectId;
+        private String contractAddress;
+        private Integer attempts;
+    }
+
+    public static SmartContractConnectFailedEvent of(String projectId, String contractAddress, Integer attempts) {
+        String eventId = UUID.randomUUID().toString();
+        String eventType = TOPIC + ".FAILED";
+
+        return SmartContractConnectFailedEvent.builder()
+                .eventId(eventId)
+                .eventType(eventType)
+                .timestamp(Instant.now())
+                .payload(SmartContractConnectFailedPayload.builder()
+                        .projectId(projectId)
+                        .contractAddress(contractAddress)
+                        .attempts(attempts)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/event/producer/KafkaMessageProducer.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/event/producer/KafkaMessageProducer.java
@@ -1,5 +1,6 @@
 package com.ddiring.Backend_BlockchainConnector.event.producer;
 
+import com.ddiring.Backend_BlockchainConnector.domain.event.SmartContractConnectFailedEvent;
 import com.ddiring.Backend_BlockchainConnector.domain.event.deploy.DeployFailedEvent;
 import com.ddiring.Backend_BlockchainConnector.domain.event.deploy.DeploySucceededEvent;
 import com.ddiring.Backend_BlockchainConnector.domain.event.deposit.DepositCancelFailedEvent;
@@ -108,5 +109,11 @@ public class KafkaMessageProducer {
         TradeFailedEvent message = TradeFailedEvent.of(projectId, tradeId, buyerAddress, sellerAddress, tradeAmount, errorType, errorMessage);
         log.info("Sending TradeFailedEvent to topic {}: {}", TradeFailedEvent.TOPIC, message);
         sendMessage(TradeFailedEvent.TOPIC, message);
+    }
+
+    public void sendContractConnectFailedEvent(String projectId, String contractAddress, Integer attempts) {
+        SmartContractConnectFailedEvent message = SmartContractConnectFailedEvent.of(projectId, contractAddress, attempts);
+        log.info("Sending SmartContractConnectFailedEvent to Topic {}: {}", SmartContractConnectFailedEvent.TOPIC, message);
+        sendMessage(SmartContractConnectFailedEvent.TOPIC, message);
     }
 }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
@@ -273,7 +273,7 @@ public class SmartContractEventManagementService {
                         } catch (Exception e) {
                             log.error("재연결 실패: {}", e.getMessage(), e);
                         }
-                    }, 10, TimeUnit.SECONDS);
+                    }, delay, TimeUnit.SECONDS);
                 }
             });
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
@@ -284,7 +284,8 @@ public class SmartContractEventManagementService {
         }
     }
 
-    private void deactivateContract(Deployment deployment) {
+    @Transactional
+    protected void deactivateContract(Deployment deployment) {
         String address = deployment.getSmartContractAddress();
         Integer attempts = reconnectAttempts.getOrDefault(address, 0);
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
@@ -229,7 +229,7 @@ public class SmartContractEventManagementService {
             return ((Flowable<?>) smartContractEventMethod.invoke(
                     contract,
                     new DefaultBlockParameterNumber(startBlockNumber),
-                    DefaultBlockParameterName.LATEST
+                    null
             )).subscribe(event -> {
                 eventFunctionMap.get(oracleEventType).eventHandlerMethod().accept((BaseEventResponse) event);
             }, throwable -> {

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
@@ -46,7 +46,7 @@ public class SmartContractEventManagementService {
 
     private final ContractWrapper contractWrapper;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     private static final int BASE_DELAY = 5;    // 초 단위
     private static final int MAX_DELAY = 300;   // 초 단위 (5분)

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/service/SmartContractEventManagementService.java
@@ -252,7 +252,8 @@ public class SmartContractEventManagementService {
             }, throwable -> {
                 log.error("[Event Flowable Subscribe Error] {}", throwable.getMessage(), throwable);
 
-                if (throwable instanceof IOException) {
+                Throwable rootCause = throwable.getCause();
+                if (throwable instanceof IOException || rootCause instanceof IOException) {
                     String address = deployment.getSmartContractAddress();
                     int attempt = reconnectAttempts.getOrDefault(address, 0) + 1; // 재연결 횟수
                     reconnectAttempts.put(address, attempt);

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -36,9 +36,6 @@ spring:
         spring.json.add.type.headers: false # 타입 헤더 추가 비활성화
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
 
-web3j:
-  polling-interval: 60000 # 60초 (60000ms)
-
 jenkins:
   url: ${JENKINS_URL}
   job: ${JENKINS_JOB}
@@ -56,3 +53,5 @@ blockchain:
   etherscan:
     api:
       key: ${ETHERSCAN_API_KEY}
+  web3j:
+    polling-interval: 60000 # 60초 (60000ms)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #49 


## 📝작업 내용

> + Web3j 통신 최적화
>   + 통신 방식 변경 및 폴링 인터벌 적용: 기존의 비효율적인 폴링 방식(eth_getFilterChanges)을 푸시(Push) 방식(eth_subscribe)으로 변경했습니다. 또한, 웹소켓 연결이 끊겼을 때 사용하는 백업 폴링의 간격을 명시적으로 설정(60초)하여 크레딧 소모를 줄였습니다.
>   + 소켓 재연결 수행: 소켓 연결이 끊어지는 IOException이 발생했을 때, 자동으로 재연결을 시도하는 로직을 추가했습니다.
>   + 재연결 백오프 전략 적용: 재연결 시도 간격을 점진적으로 늘리는 백오프 전략을 적용하여 네트워크 및 서버에 가해지는 부하를 줄였습니다.
>   + 재연결 시도 횟수 초과 시, 이벤트 발행: 정해진 횟수(최대 10회)를 초과하여 재연결에 실패할 경우, 해당 스마트 컨트랙트를 비활성화하고 Kafka를 통해 관련 이벤트를 발행하도록 했습니다.
> + 코드 안정성 및 효율 개선
>   + 스레드 풀 관리: 재연결 로직에 사용되는 스케줄러의 스레드 풀 크기를 하나로 고정하여, 불필요하게 많은 스레드가 생성되는 것을 방지했습니다.
>   + 소켓 연결 오류 감지 확장: IOException 외의 다양한 웹소켓 관련 예외도 감지하여 재연결을 트리거하도록 오류 감지 로직을 확장했습니다.
>   + 스마트 컨트랙트 상태 업데이트 트랜잭션 처리: 재연결 로직 내에서 스마트 컨트랙트 상태를 업데이트하는 DB 작업이 하나의 트랜잭션으로 처리되도록 수정하여 데이터 일관성을 보장했습니다.

## 💬 리뷰 요구사항

> 없음
