### PR TITLE
[Feat] [Scrum-252] 블록체인 로그 출력

### DIFF
--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/api/open/SmartContractController.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/api/open/SmartContractController.java
@@ -50,4 +50,11 @@ public class SmartContractController {
 
         return ApiResponseDto.createOK(response);
     }
+
+    @GetMapping(value = "/logs")
+    public ApiResponseDto<?> getLogs(@ModelAttribute @Valid LogsDto.Request logsDto) {
+        LogsDto.Response response = smartContractService.getLogs(logsDto);
+
+        return ApiResponseDto.createOK(response);
+    }
 }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
@@ -1,0 +1,80 @@
+package com.ddiring.Backend_BlockchainConnector.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.math.BigInteger;
+import java.util.List;
+
+public class EtherscanEventLogDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+        @Positive
+        Long chainId;
+        @NotBlank
+        String module;
+        @NotBlank
+        String action;
+        @NotBlank
+        String contractaddress;
+        @NotBlank
+        String address;
+        @Positive
+        Long page;
+        @Positive
+        Long offset;
+        @Positive
+        Long startblock;
+        @Positive
+        Long endblock;
+        @NotBlank
+        String sort;
+        @NotBlank
+        String apiKey;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Response {
+        @NotBlank
+        private String status;
+        @NotBlank
+        private String message;
+        @NotEmpty
+        private List<TokenTransaction> result;
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class TokenTransaction {
+            private Long blockNumber;
+            private Long timeStamp;
+            private String hash;
+            private String nonce;
+            private String blockHash;
+            private String from;
+            private String contractAddress;
+            private String to;
+
+            private BigInteger value;
+            private BigInteger gas;
+            private BigInteger gasPrice;
+            private BigInteger gasUsed;
+            private BigInteger cumulativeGasUsed;
+
+            private String tokenName;
+            private String tokenSymbol;
+            private String tokenDecimal;
+            private String transactionIndex;
+            private String input;
+            private Long confirmations;
+        }
+    }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
@@ -97,4 +97,20 @@ public class EtherscanEventLogDto {
                 .apiKey(apiKey)
                 .build();
     }
+
+    public static LogsDto.Response.TransactionLog toLogsResponse(Response.TokenTransaction tokenTransaction, String transactionType) {
+        LocalDateTime transactionTime = Instant.ofEpochSecond(tokenTransaction.getTimeStamp()).atZone(ZoneId.of("UTC")).toLocalDateTime();
+        Long value = tokenTransaction.getValue().divide(BigInteger.TEN.pow(tokenTransaction.getTokenDecimal().intValue())).longValue();
+
+        return LogsDto.Response.TransactionLog.builder()
+                .blockNumber(tokenTransaction.getBlockNumber())
+                .timeStamp(transactionTime)
+                .transactionHash(tokenTransaction.getHash())
+                .fromAddress(tokenTransaction.getFrom())
+                .contractAddress(tokenTransaction.getContractAddress())
+                .toAddress(tokenTransaction.getTo())
+                .value(value)
+                .transactionType(transactionType)
+                .build();
+    }
 }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
@@ -78,3 +78,20 @@ public class EtherscanEventLogDto {
             private Long confirmations;
         }
     }
+
+    public static Request of (LogsDto.Request logsDto, Long chainId, String contractAddress, String apiKey) {
+        return Request.builder()
+                .chainId(chainId)
+                .module("account")
+                .action("tokentx")
+                .contractaddress(contractAddress)
+                .address(logsDto.getUserAddress())
+                .startblock(0L)
+                .endblock(Long.MAX_VALUE)
+                .page(logsDto.getPage())
+                .offset(logsDto.getOffset())
+                .sort(logsDto.getSort())
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/EtherscanEventLogDto.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 public class EtherscanEventLogDto {
@@ -72,7 +75,7 @@ public class EtherscanEventLogDto {
 
             private String tokenName;
             private String tokenSymbol;
-            private String tokenDecimal;
+            private Long tokenDecimal;
             private String transactionIndex;
             private String input;
             private Long confirmations;

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
@@ -1,0 +1,48 @@
+package com.ddiring.Backend_BlockchainConnector.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class LogsDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+        @NotBlank
+        String projectId;
+        @NotBlank
+        String userAddress;
+        @Positive
+        Long page;
+        @Positive
+        Long offset;
+        @NotBlank
+        String sort;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Response {
+            @Positive
+            Long blockNumber;
+            @NotEmpty
+            LocalDateTime timeStamp;
+            @NotBlank
+            String transactionHash;
+            @NotBlank
+            String fromAddress;
+            @NotBlank
+            String contractAddress;
+            @NotBlank
+            String toAddress;
+            @Positive
+            Long value;
+    }
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
@@ -32,6 +32,12 @@ public class LogsDto {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Response {
         private List<TransactionLog> result;
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        public static class TransactionLog {
             @Positive
             Long blockNumber;
             @NotEmpty
@@ -46,5 +52,8 @@ public class LogsDto {
             String toAddress;
             @Positive
             Long value;
+            @NotBlank
+            String transactionType;
+        }
     }
 }

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/dto/LogsDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class LogsDto {
     @Getter
@@ -30,6 +31,7 @@ public class LogsDto {
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Response {
+        private List<TransactionLog> result;
             @Positive
             Long blockNumber;
             @NotEmpty

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/enums/BlockchainRequestType.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/domain/enums/BlockchainRequestType.java
@@ -8,7 +8,8 @@ public enum BlockchainRequestType {
     INVESTMENT("INVESTMENT"),
     DEPOSIT("DEPOSIT"),
     CANCEL_DEPOSIT("CANCEL_DEPOSIT"),
-    TRADE("TRADE");
+    TRADE("TRADE"),
+    ETC("ETC");
 
     private final String requestType;
 

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/remote/log/RemoteEtherscanService.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/remote/log/RemoteEtherscanService.java
@@ -1,0 +1,32 @@
+package com.ddiring.Backend_BlockchainConnector.remote.log;
+
+import com.ddiring.Backend_BlockchainConnector.domain.dto.EtherscanEventLogDto;
+import jakarta.validation.Valid;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Map;
+
+@FeignClient(name = "RemoteEtherscanService", url = "https://api.etherscan.io")
+public interface RemoteEtherscanService {
+
+    @GetMapping(value = "/v2/api")
+    EtherscanEventLogDto.Response getLogsFromEtherScan(
+            @RequestParam("chainid") Long chainId,
+            @RequestParam("module") String module,
+            @RequestParam("action") String action,
+            @RequestParam("contractaddress") String contractAddress,
+            @RequestParam("address") String address,
+            @RequestParam("page") Long page,
+            @RequestParam("offset") Long offset,
+            @RequestParam("startblock") Long startBlock,
+            @RequestParam("endblock") Long endBlock,
+            @RequestParam("sort") String sort,
+            @RequestParam("apikey") String apiKey
+    );
+}

--- a/src/main/java/com/ddiring/Backend_BlockchainConnector/repository/BlockchainLogRepository.java
+++ b/src/main/java/com/ddiring/Backend_BlockchainConnector/repository/BlockchainLogRepository.java
@@ -27,4 +27,6 @@ public interface BlockchainLogRepository extends JpaRepository<BlockchainLog, Lo
     Boolean existsByProjectIdAndOrderIdAndRequestType(@NotBlank  String projectId, Long orderId, BlockchainRequestType requestType);
 
     Boolean existsByProjectIdAndRequestStatus(@NotBlank String projectId, BlockchainRequestStatus requestStatus);
+
+    List<BlockchainLog> findByRequestTransactionHashInOrOracleTransactionHashIn(List<String> requestTransactionHashes, List<String> oracleTransactionHashes);
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,5 @@
+spring:
+  config:
+    import:
+      - file:/etc/config/application-prod.yaml
+      - file:/etc/secret/application-secret.yaml


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58 


## 📝작업 내용
> <img width="791" height="426" alt="image" src="https://github.com/user-attachments/assets/4b54e6fb-cdd9-4a4a-8bdc-9e73123bbcd4" />


> 1. Etherscan API 연동:
>    + Etherscan API 요청 및 응답을 위한 **DTO(Data Transfer Object)**를 정의했습니다.
>    + API 요청을 쉽게 구성할 수 있는 헬퍼(Helper) 함수를 구현했습니다.
>    + Feign Client를 설정하여 실제 Etherscan API를 호출하는 로직을 추가했습니다.
> 2. 데이터 처리 및 로직 개선:
>    + timeStamp를 포함한 여러 필드의 **타입을 변경(Fix)**하여 데이터 정확성을 높였습니다. 특히, BigInteger와 Long 타입을 적절히 사용했습니다.
>    + Etherscan에서 받은 트랜잭션 해시를 기반으로 백엔드 DB에 저장된 **요청 타입(request type)**을 조회하는 기능을 추가했습니다. 이때, IN 절을 사용한 배치 조회를 통해 N+1 쿼리 문제를 해결했습니다.
>    + 요청 타입에 ETC Enum을 추가하여 새로운 유형의 트랜잭션을 처리할 수 있도록 확장했습니다.
>    + 블록체인 요청 및 응답 로그를 상세하게 출력하는 서비스 로직을 구현했습니다.
> 3. 프론트엔드 연동 및 API 구현:
>    + 프론트엔드와의 통신을 위한 요청 및 응답 DTO를 구성했습니다.
>    + 백엔드에서 Etherscan 응답을 프론트엔드가 요구하는 형식으로 변환하는 함수를 구현했습니다.
>    + 블록체인 로그를 프론트엔드에 제공하기 위한 REST API 엔드포인트를 추가했습니다.
> 4. 운영 환경 설정:
>    + 운영 환경 배포를 위한 설정 파일을 추가하여, 빌드 및 배포 프로세스를 용이하게 했습니다.


## 💬 리뷰 요구사항

> 없음
